### PR TITLE
Add conversion to binary for Publish message contents 

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -15,7 +15,7 @@ func (*Mqtt) Publish(
 	client paho.Client,
 	topic string,
 	qos int,
-	message string,
+	message byte,
 	retain bool,
 	timeout int,
 ) {

--- a/publish.go
+++ b/publish.go
@@ -3,11 +3,27 @@ package mqtt
 import (
 	"context"
 	"time"
+	"encoding/hex"
 
 	paho "github.com/eclipse/paho.mqtt.golang"
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/lib"
 )
+
+
+func asHex(
+	stringVal string,
+	convertToBin bool,
+) interface{} {
+	if convertToBin == true {
+		data, err := hex.DecodeString(stringVal)
+			if err != nil {
+				panic(err)
+			}
+			return data
+	}
+	return stringVal
+}
 
 // Publish allow to publish one message
 func (*Mqtt) Publish(
@@ -15,9 +31,10 @@ func (*Mqtt) Publish(
 	client paho.Client,
 	topic string,
 	qos int,
-	message byte,
+	message string,
 	retain bool,
 	timeout int,
+	hex2bin bool,
 ) {
 	state := lib.GetState(ctx)
 	if state == nil {
@@ -28,8 +45,8 @@ func (*Mqtt) Publish(
 		common.Throw(common.GetRuntime(ctx), ErrorClient)
 		return
 	}
-
-	token := client.Publish(topic, byte(qos), retain, message)
+	outboundMessage := asHex(message, hex2bin)
+	token := client.Publish(topic, byte(qos), retain, outboundMessage)
 	if !token.WaitTimeout(time.Duration(timeout) * time.Millisecond) {
 		common.Throw(common.GetRuntime(ctx), ErrorTimeout)
 		return

--- a/subscribe.go
+++ b/subscribe.go
@@ -60,7 +60,8 @@ func (*Mqtt) Consume(
 	token chan paho.Message,
 	// timeout ms
 	timeout uint,
-) string {
+	returnBin bool,
+) interface {} {
 	state := lib.GetState(ctx)
 	if state == nil {
 		common.Throw(common.GetRuntime(ctx), ErrorState)
@@ -73,7 +74,11 @@ func (*Mqtt) Consume(
 
 	select {
 	case msg := <-token:
-		return string(msg.Payload())
+		if returnBin {
+			return msg.Payload()
+		} else {
+			return string(msg.Payload())
+		}
 	case <-time.After(time.Millisecond * time.Duration(timeout)):
 		common.Throw(common.GetRuntime(ctx), ErrorTimeout)
 		return ""


### PR DESCRIPTION
Had a need to send binary content so added sort of a workaround that converts a hex string in to bytes. Ideally it should detect JS type automatically, but this is the first time for me with GO so did not want to go too deep. Therefore if someone has better suggestions on how to achieve it, I'm all in. This is an attempt to fix issue:  #2 .