### PR TITLE
option to specify tls min version

### DIFF
--- a/client.go
+++ b/client.go
@@ -103,7 +103,6 @@ func getLabels(labelsArg sobek.Value, rt *sobek.Runtime) mqttMetricsLabels {
 
 func tlsVersionStringToNumber(version string) (uint16, error) {
 	versionMap := map[string]uint16{
-		"SSLv3":   tls.VersionSSL30,
 		"TLS 1.0": tls.VersionTLS10,
 		"TLS 1.1": tls.VersionTLS11,
 		"TLS 1.2": tls.VersionTLS12,
@@ -247,7 +246,7 @@ func (c *client) Connect() error {
 		}
 		tlsConfig = &tls.Config{
 			RootCAs:    rootCA,
-			MinVersion: c.conf.tlsMinVersion,
+			MinVersion: c.conf.tlsMinVersion, // #nosec G402
 		}
 	}
 	// Use local cert if specified
@@ -261,7 +260,7 @@ func (c *client) Connect() error {
 		} else {
 			tlsConfig = &tls.Config{
 				Certificates: []tls.Certificate{cert},
-				MinVersion:   c.conf.tlsMinVersion,
+				MinVersion:   c.conf.tlsMinVersion, // #nosec G402
 			}
 		}
 	}

--- a/errors.go
+++ b/errors.go
@@ -13,6 +13,8 @@ var (
 	ErrClient = errors.New("client is not connected")
 	// ErrTimeout operation timeout
 	ErrTimeout = errors.New("operation timeout")
+	// ErrTimeoutToLong timeout value is too large
+	ErrTimeoutToLong = errors.New("timeout value is too large")
 	// ErrSubscribe failed to subscribe to mqtt topic
 	ErrSubscribe = errors.New("subscribe failure")
 	// ErrConsumeToken consume token is invalid


### PR DESCRIPTION
I added an option to specify a min tls version. By default tls 1.3 is used, the parameter in client is optional, so it should not break any existing code.

This pull request is related to #36 