### PR TITLE
IsConnectionOpen function for checking active connection with Broker

### DIFF
--- a/client.go
+++ b/client.go
@@ -231,6 +231,8 @@ func (m *MqttAPI) defineRuntimeMethods(client *client) {
 	must(client.obj.DefineDataProperty(
 		"isConnected", rt.ToValue(client.IsConnected), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
 	must(client.obj.DefineDataProperty(
+		"isConnectionOpen", rt.ToValue(client.IsConnectionOpen), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+	must(client.obj.DefineDataProperty(
 		"publish", rt.ToValue(client.Publish), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
 	must(client.obj.DefineDataProperty(
 		"subscribe", rt.ToValue(client.Subscribe), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
@@ -333,6 +335,15 @@ func (c *client) IsConnected() bool {
 		return false
 	}
 	return true
+}
+
+// IsConnectionOpen for the given client
+// Checks client has an active connection to broker i.e not in disconnected or reconnect mode
+func (c *client) IsConnectionOpen() bool {
+	if c.pahoClient == nil {
+		return false
+	}
+	return c.pahoClient.IsConnectionOpen()
 }
 
 // error event for async


### PR DESCRIPTION
### This Pull Request is associated with issue(s):

https://github.com/pmalhaire/xk6-mqtt/issues/26

### Brief summary of the problem/need for this:

The current IsConnected function in the plugin uses the `IsConnected` function provided by the  Eclipse Paho package. The documentation for Paho is a bit vague but says the `IsConnected` function: 

> // IsConnected returns a bool signifying whether
   // the client is connected or not.

It does not seem to be aware of changes in the connection status or whether a client is trying to reconnect.

### Detail of how this Pull Request solves the problem/need:

Paho also offers a function called `IsConnectionOpen` the documentation for this function suggests that it is aware of whether the client has an active connection to the broker.

> // IsConnectionOpen return a bool signifying whether the client has an active
   // connection to mqtt broker, i.e not in disconnected or reconnect mode

Rather than replacing the implementation of IsConnected I have added IsConnectionOpen as a new option to maintain backwards compatibility and allow developers to choose which one is better suited to their needs
